### PR TITLE
feat: add event offset column to aggregate tables

### DIFF
--- a/pgeventstore/model.go
+++ b/pgeventstore/model.go
@@ -7,8 +7,10 @@ import (
 	"time"
 )
 
+// Update the event struct to include Offset
 type event struct {
 	ID               sql.NullString  `db:"id"`
+	Offset           sql.NullInt64   `db:"offset"` // New field
 	OccurredAt       sql.NullTime    `db:"occurred_at"`
 	RegisteredAt     sql.NullTime    `db:"registered_at"`
 	Type             sql.NullString  `db:"type"`


### PR DESCRIPTION
- Add automatic migration to create an "offset" column in all aggregate tables
- Properly quote "offset" keyword in SQL statements to avoid PostgreSQL syntax errors
- Populate existing records with sequential offsets based on chronological order
- Ensure column is non-nullable after population
- Maintain backward compatibility with existing data

This change enables global event ordering across aggregates, which improves event replay capabilities and supports more advanced event sourcing patterns like subscriptions and projections.